### PR TITLE
Add Conda build/test files for Symbiyosys and Boolector/Z3 solvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
      env:
      - PACKAGE=bit/prjtrellis
 
+
    # EDA Tools - Synthesis
    - stage: "EDA Tools"
      env:
@@ -51,6 +52,11 @@ jobs:
    - stage: "EDA Tools"
      env:
      - PACKAGE=sim/verilator
+
+   # EDA Tools - Formal
+   - stage: "EDA Tools"
+     env:
+     - PACKAGE=formal/symbiyosys
 
 before_install:
  - source $TRAVIS_BUILD_DIR/.travis/common.sh

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Conda recipes for FPGA EDA tools (for synthesis, place and route and bitstream g
  * [Icarus Verilog](http://iverilog.icarus.com/)
  * [Verilator](https://www.veripool.org/wiki/verilator)
 
+# Formal
+ 
+ * [Symbiyosys](https://github.com/YosysHQ/SymbiYosys)
+
 # Building
 
 This repository is set up to be built by Travis CI, using the GitHub

--- a/formal/symbiyosys/build.sh
+++ b/formal/symbiyosys/build.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#****************************************************************************
+#* build.sh
+#* 
+#* Conda package build script for SymbiYosys and supporting solvers
+#****************************************************************************
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+cwd=`pwd`
+
+CFLAGS_ORIG=${CFLAGS}
+
+#********************************************************************
+#* Build Boolector
+#********************************************************************
+cd ${cwd}
+
+# CFLAGS=`echo ${CFLAGS_ORIG} | sed -e 's/-O[0-9]//g'`
+unset CFLAGS
+
+git clone https://github.com/Boolector/boolector.git
+
+cd ${cwd}/boolector
+
+# ilingeling.c contains a variable named 'clone'
+# This conflicts with the clone function, so we rename it
+sed -i -e 's%cd ${LINGELING_DIR}%cd ${LINGELING_DIR}\nsed -i -e "s/\\<clone\\>/_clone/g" ilingeling.c%' contrib/setup-lingeling.sh
+
+echo "CFLAGS=${CFLAGS}"
+./contrib/setup-btor2tools.sh
+if test $? -ne 0; then exit 1; fi
+
+./contrib/setup-lingeling.sh
+if test $? -ne 0; then exit 1; fi
+
+echo "CFLAGS=${CFLAGS}"
+./configure.sh --prefix ${PREFIX}
+if test $? -ne 0; then exit 1; fi
+
+cd build
+
+make -j${CPU_COUNT}
+if test $? -ne 0; then exit 1; fi
+
+make install
+if test $? -ne 0; then exit 1; fi
+
+CFLAGS=${CFLAGS_ORIG}
+
+#********************************************************************
+#* Build Z3
+#********************************************************************
+cd ${cwd}
+
+git clone https://github.com/Z3Prover/z3.git z3
+if test $? -ne 0; then exit 1; fi
+
+cd z3
+python scripts/mk_make.py
+if test $? -ne 0; then exit 1; fi
+
+cd build
+
+make -j${CPU_COUNT}
+if test $? -ne 0; then exit 1; fi
+
+make PREFIX=${PREFIX} install
+if test $? -ne 0; then exit 1; fi
+
+#********************************************************************
+#* Build Yices2
+#* Note: disabled due to issues finding libgmp
+#********************************************************************
+#cd ${cwd}
+#
+#git clone https://github.com/SRI-CSL/yices2.git yices2
+#if test $? -ne 0; then exit 1; fi
+#
+#cd yices2
+#autoconf
+#if test $? -ne 0; then exit 1; fi
+#
+#./configure --prefix=${PREFIX}
+#if test $? -ne 0; then exit 1; fi
+#
+#make -j${CPU_COUNT}
+#if test $? -ne 0; then exit 1; fi
+#
+#make install
+#if test $? -ne 0; then exit 1; fi
+
+#********************************************************************
+#* Build SymbiYosys
+#********************************************************************
+cd ${cwd}
+make -j$CPU_COUNT
+make PREFIX=${PREFIX} install
+
+# Fix hard coded paths in verilator
+# sed -i -e's-/.*_build_env/bin/--' $PREFIX/share/verilator/include/verilated.mk
+

--- a/formal/symbiyosys/build.sh
+++ b/formal/symbiyosys/build.sh
@@ -13,24 +13,15 @@ if [ x"$TRAVIS" = xtrue ]; then
 fi
 
 cwd=`pwd`
-
 CFLAGS_ORIG=${CFLAGS}
 
 #********************************************************************
 #* Build Boolector
 #********************************************************************
-cd ${cwd}
 
-# CFLAGS=`echo ${CFLAGS_ORIG} | sed -e 's/-O[0-9]//g'`
 unset CFLAGS
 
-git clone https://github.com/Boolector/boolector.git
-
 cd ${cwd}/boolector
-
-# ilingeling.c contains a variable named 'clone'
-# This conflicts with the clone function, so we rename it
-sed -i -e 's%cd ${LINGELING_DIR}%cd ${LINGELING_DIR}\nsed -i -e "s/\\<clone\\>/_clone/g" ilingeling.c%' contrib/setup-lingeling.sh
 
 echo "CFLAGS=${CFLAGS}"
 ./contrib/setup-btor2tools.sh
@@ -56,12 +47,8 @@ CFLAGS=${CFLAGS_ORIG}
 #********************************************************************
 #* Build Z3
 #********************************************************************
-cd ${cwd}
 
-git clone https://github.com/Z3Prover/z3.git z3
-if test $? -ne 0; then exit 1; fi
-
-cd z3
+cd ${cwd}/z3
 python scripts/mk_make.py
 if test $? -ne 0; then exit 1; fi
 
@@ -98,7 +85,7 @@ if test $? -ne 0; then exit 1; fi
 #********************************************************************
 #* Build SymbiYosys
 #********************************************************************
-cd ${cwd}
+cd ${cwd}/SymbiYosys
 make -j$CPU_COUNT
 make PREFIX=${PREFIX} install
 

--- a/formal/symbiyosys/build.sh
+++ b/formal/symbiyosys/build.sh
@@ -102,6 +102,4 @@ cd ${cwd}
 make -j$CPU_COUNT
 make PREFIX=${PREFIX} install
 
-# Fix hard coded paths in verilator
-# sed -i -e's-/.*_build_env/bin/--' $PREFIX/share/verilator/include/verilated.mk
 

--- a/formal/symbiyosys/fixup_lingeling.patch
+++ b/formal/symbiyosys/fixup_lingeling.patch
@@ -1,0 +1,15 @@
+diff -rcNB contrib/setup-lingeling.sh contrib/setup-lingeling.sh
+*** contrib/setup-lingeling.sh	2020-01-18 12:21:52.740076871 -0800
+--- contrib/setup-lingeling.sh	2020-01-18 12:22:50.881077999 -0800
+***************
+*** 10,15 ****
+--- 10,18 ----
+  download_github "arminbiere/lingeling" "$COMMIT_ID" "$LINGELING_DIR"
+  cd ${LINGELING_DIR}
+  
++ # rename 'clone' to '_clone'
++ sed -i -e "s/\\<clone\\>/_clone/g" ilingeling.c
++ 
+  if is_windows; then
+    component="Lingeling"
+    last_patch_date="20190110"

--- a/formal/symbiyosys/meta.yaml
+++ b/formal/symbiyosys/meta.yaml
@@ -1,18 +1,22 @@
-{% set version = '1.1.1' %}
+{% set version = '%s.0_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: symbiyosys
   version: {{ version }}
 
 source:
-  git_rev: master
-  git_url: https://github.com/YosysHQ/SymbiYosys.git
+  - git_url: https://github.com/mballance/SymbiYosys.git
+    folder: SymbiYosys
+  - git_url: https://github.com/Boolector/boolector.git
+    folder: boolector
+    patches:
+      - fixup_lingeling.patch
+  - git_url: https://github.com/Z3Prover/z3.git
+    folder: z3
 
 build:
   detect_binary_files_with_prefix: True
-  # number: 201803050325
   number: {{ environ.get('DATE_NUM') }}
-  # string: 20180305_0325
   string: {{ environ.get('DATE_STR') }}
   script_env:
     - CI
@@ -22,6 +26,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - curl
     - gperf
     - gmp
   host:

--- a/formal/symbiyosys/meta.yaml
+++ b/formal/symbiyosys/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = '1.1.1' %}
+
+package:
+  name: symbiyosys
+  version: {{ version }}
+
+source:
+  git_rev: master
+  git_url: https://github.com/YosysHQ/SymbiYosys.git
+
+build:
+  detect_binary_files_with_prefix: True
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - gperf
+    - gmp
+  host:
+    - yosys
+  run:
+    - yosys
+
+test:
+  files:
+    - test/demo3.sby
+
+about:
+  home: http://symbiyosys.readthedocs.io
+  license: ISC
+  summary: 'SymbiYosys (sby) is a front-end driver program for Yosys-based formal hardware verification flows.'

--- a/formal/symbiyosys/run_test.sh
+++ b/formal/symbiyosys/run_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set +x
+
+echo "TEST: pwd=`pwd`"
+echo "TEST: dir: `ls`"
+
+$PREFIX/bin/sby test/demo3.sby > output 2>&1
+
+passed=`grep 'Status: passed' output | wc -l`
+
+if test $passed -ne 1; then
+  echo "Error: test failed"
+  cat output
+  exit 1
+fi
+

--- a/formal/symbiyosys/test/demo3.sby
+++ b/formal/symbiyosys/test/demo3.sby
@@ -1,0 +1,53 @@
+[options]
+depth 10
+mode bmc
+
+[engines]
+smtbmc boolector
+
+[script]
+read_verilog -formal demo.v
+prep -top top
+
+[file demo.v]
+module top (
+  input clk,
+  input [7:0] addr,
+  input [7:0] wdata,
+  output [7:0] rdata,
+);
+  const rand reg [7:0] test_addr;
+  reg [7:0] test_data;
+  reg test_valid = 0;
+
+  always @(posedge clk) begin
+    if (addr == test_addr) begin
+      if (test_valid)
+        assert(test_data == rdata);
+      test_data <= wdata;
+      test_valid <= 1;
+    end
+  end
+
+  memory uut (
+    .clk  (clk  ),
+    .addr (addr ),
+    .wdata(wdata),
+    .rdata(rdata)
+  );
+endmodule
+
+
+module memory (
+  input clk,
+  input [7:0] addr,
+  input [7:0] wdata,
+  output [7:0] rdata,
+);
+  reg [7:0] mem [0:255];
+
+  always @(posedge clk)
+    mem[addr] <= wdata;
+
+  assign rdata = mem[addr];
+endmodule


### PR DESCRIPTION
This PR adds support for building Symbiyosys on Linux platforms. 
I'm aware of one open issue that I could use some advice with: obtaining a version. I used the Verilator meta.yaml file as a basis for the Symbiyosys one, but the Verilator version mechanism doesn't work well for Symbiyosys. Any advice on typical approaches?