### PR TITLE
Enable verilator build to support FST tracing

### DIFF
--- a/sim/verilator/conda-inttypes.patch
+++ b/sim/verilator/conda-inttypes.patch
@@ -1,0 +1,16 @@
+diff -rcNB include/verilated_fst_c.cpp include/verilated_fst_c.cpp
+*** include/verilated_fst_c.cpp	2020-01-18 17:01:01.169401820 -0800
+--- include/verilated_fst_c.cpp	2020-01-18 18:54:47.301534259 -0800
+***************
+*** 20,25 ****
+--- 20,29 ----
+  //=============================================================================
+  // SPDIFF_OFF
+  
++ // With some GCC versions, inttypes.h only
++ // declares PRI macros if this is declared
++ #define __STDC_FORMAT_MACROS
++ 
+  #include "verilatedos.h"
+  #include "verilated.h"
+  #include "verilated_fst_c.h"

--- a/sim/verilator/meta.yaml
+++ b/sim/verilator/meta.yaml
@@ -7,6 +7,8 @@ package:
 source:
   git_rev: master
   git_url: http://git.veripool.org/git/verilator
+  patches:
+    - conda-inttypes.patch
 
 build:
   detect_binary_files_with_prefix: True
@@ -27,6 +29,7 @@ requirements:
     - {{ compiler('cxx') }}
     - bison
     - flex
+    - zlib
   run:
     - {{ compiler('cxx') }}
   {% for package in resolved_packages('host') %}

--- a/sim/verilator/run_test.sh
+++ b/sim/verilator/run_test.sh
@@ -21,7 +21,8 @@ int main(int argc, char **argv, char **env) {
     exit(0);
 }
 EOF
-	$PREFIX/bin/verilator --cc $FILENAME.v $2 $3 --exe sim_main.cpp
+	$PREFIX/bin/verilator --cc --trace-fst \
+            $FILENAME.v $2 $3 --exe sim_main.cpp
 	cd obj_dir
 	cat V$FILENAME.mk
 	make -j -f V$FILENAME.mk V$FILENAME


### PR DESCRIPTION
In order for Verilator to support FST tracing with Conda, the package needs to call out 'zlib' as a dependency, and the tracing file needs to define __STD_FORMAT_MACROS. This patch adds these changes, and ensures they are tested by the build tests.

Signed-off-by: Matthew Ballance <matt.ballance@gmail.com>