### PR TITLE
Fix macOS compiling problems

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,3 @@
+CONDA_BUILD_SYSROOT:
+  - /Users/travis/sdk/MacOSX10.9.sdk        # [osx]
+


### PR DESCRIPTION
`conda-build` v20.1+ doesn't have any default value defined for `CONDA_BUILD_SYSROOT` anymore and the `conda_build_config.yaml` from `.travis` is ignored by `conda-build`.