### PR TITLE
Add prjxray-db & prjxray-tools package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=bit/prjtrellis
+  - stage: "No dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=bit/prjxray-db
   # Windows
   - stage: "No dependencies"
     os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,11 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=bit/prjxray-db
+  - stage: "No dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=bit/prjxray-tools
   # Windows
   - stage: "No dependencies"
     os: windows

--- a/bit/prjxray-db/build.sh
+++ b/bit/prjxray-db/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+DEVICES="artix7 kintex7 zynq7"
+DBDIR="${PREFIX}/share/symbiflow/prjxray-db"
+
+mkdir -p $DBDIR
+
+for device in $DEVICES; do
+    cp -r $device $DBDIR
+done
+
+mkdir -p $PREFIX/bin
+
+DB_CONFIG="${PREFIX}/bin/prjxray-config"
+
+echo -e "#!/bin/bash\n\necho ${DBDIR}" > ${DB_CONFIG}
+chmod +x ${DB_CONFIG}

--- a/bit/prjxray-db/meta.yaml
+++ b/bit/prjxray-db/meta.yaml
@@ -1,0 +1,24 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: prjxray-db
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/prjxray-db.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+about:
+  home: https://github.com/SymbiFlow/prjxray-db
+  license: CC0-1.0
+  license_file: LICENSE
+  summary: 'Project X-Ray Database: XC7 Series.'

--- a/bit/prjxray-tools/build.sh
+++ b/bit/prjxray-tools/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=${PREFIX} ..
+make -j$(nproc)
+make install
+

--- a/bit/prjxray-tools/condarc
+++ b/bit/prjxray-tools/condarc
@@ -1,0 +1,3 @@
+channels:
+  - pkgw-forge
+  - conda-forge

--- a/bit/prjxray-tools/meta.yaml
+++ b/bit/prjxray-tools/meta.yaml
@@ -1,0 +1,31 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: prjxray-tools
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/prjxray.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - cmake
+
+about:
+  home: https://github.com/SymbiFlow/prjxray
+  license: ISC
+  license_file: LICENSE
+  summary: 'Documenting the Xilinx 7-series bit-stream format.'


### PR DESCRIPTION
This recipe is based on 'Symbiflow/conda-packages' one.

fpga-tool-perf depends on prjxray-db
symbiflow-examples depends on both prjxray-db and prjxray-tools