### PR TITLE
Add `quicklogic-vtr` and `quicklogic-vtr-gui` recipes for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,6 +171,16 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=pnr/symbiflow-vtr-gui
+  - stage: "No dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=pnr/quicklogic-vtr
+  - stage: "No dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=pnr/quicklogic-vtr-gui
   - stage: "Has first level dependencies"
     os: linux
     dist: xenial

--- a/pnr/quicklogic-vtr-gui/build.sh
+++ b/pnr/quicklogic-vtr-gui/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+echo "============================================================"
+echo "CFLAGS='$CFLAGS'"
+echo "CXXFLAGS='$CXXFLAGS'"
+echo "CPPFLAGS='$CPPFLAGS'"
+echo "DEBUG_CXXFLAGS='$DEBUG_CXXFLAGS'"
+echo "DEBUG_CPPFLAGS='$DEBUG_CPPFLAGS'"
+echo "LDFLAGS='$LDFLAGS'"
+echo "------------------------------------------------------------"
+# -Wundef causes warnings on undefined preprocessor defines (e.g. o
+# tbb_config.h:56:7: warning: "__GLIBCPP__" is not defined, evaluates to 0 [-Wundef]
+# elif __GLIBCPP__ || __GLIBCXX__
+export CFLAGS="$(echo $CFLAGS | sed -e's/-Wundef //') -w"
+export CXXFLAGS="$(echo $CXXFLAGS | sed -e's/-Wundef //') -w"
+export CPPFLAGS="$(echo $CPPFLAGS | sed -e's/-Wundef //')"
+export DEBUG_CXXFLAGS="$(echo $DEBUG_CXXFLAGS | sed -e's/-Wundef //') -w"
+export DEBUG_CPPFLAGS="$(echo $DEBUG_CPPFLAGS | sed -e's/-Wundef //')"
+echo "CFLAGS='$CFLAGS'"
+echo "CXXFLAGS='$CXXFLAGS'"
+echo "CPPFLAGS='$CPPFLAGS'"
+echo "DEBUG_CXXFLAGS='$DEBUG_CXXFLAGS'"
+echo "DEBUG_CPPFLAGS='$DEBUG_CPPFLAGS'"
+echo "LDFLAGS='$LDFLAGS'"
+env
+export M4=${PREFIX}/bin/m4
+mkdir build
+cd build
+# ODIN and ABC are disabled to keep build time less than Travis CI timeout.
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_ODIN=OFF \
+    -DWITH_ABC=OFF \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    ..
+grep -i flags CMakeCache.txt
+make -k -j$CPU_COUNT || make VERBOSE=1
+make test
+make -j$CPU_COUNT install
+
+mkdir -p ${PREFIX}/lib
+mv ${PREFIX}/bin/*.a ${PREFIX}/lib/

--- a/pnr/quicklogic-vtr-gui/condarc
+++ b/pnr/quicklogic-vtr-gui/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/pnr/quicklogic-vtr-gui/meta.yaml
+++ b/pnr/quicklogic-vtr-gui/meta.yaml
@@ -1,0 +1,57 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-','_') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+package:
+  name: vtr-gui
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/vtr-verilog-to-routing.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - python  {{ python }}
+  host:
+    - bison 3.4
+    - cairo
+    - cmake
+    - flex
+    - fontconfig
+    - ncurses
+    - pkg-config
+    - readline
+    - tk
+    - xorg-libice
+    - xorg-libsm
+    - xorg-libx11
+    - xorg-libxcb
+    - xorg-libxext
+    - xorg-libxft
+  run:
+    - readline
+    - tk
+    - cairo
+    - fontconfig
+    - xorg-libx11
+    - xorg-libxft
+
+#test:
+#  commands:
+#    - ./run_reg_test.pl vtr_reg_basic
+#    - ./run_reg_test.pl vtr_reg_strong -j2
+
+about:
+  home: http://verilogtorouting.org/
+  license: MIT
+  license_file: LICENSE.md
+  summary: 'The Verilog-to-Routing (VTR) project is a world-wide collaborative effort to provide a open-source framework for conducting FPGA architecture and CAD research and development. The VTR design flow takes as input a Verilog description of a digital circuit, and a description of the target FPGA architecture.'

--- a/pnr/quicklogic-vtr/build.sh
+++ b/pnr/quicklogic-vtr/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+echo "============================================================"
+echo "CFLAGS='$CFLAGS'"
+echo "CXXFLAGS='$CXXFLAGS'"
+echo "CPPFLAGS='$CPPFLAGS'"
+echo "DEBUG_CXXFLAGS='$DEBUG_CXXFLAGS'"
+echo "DEBUG_CPPFLAGS='$DEBUG_CPPFLAGS'"
+echo "LDFLAGS='$LDFLAGS'"
+echo "------------------------------------------------------------"
+# -Wundef causes warnings on undefined preprocessor defines (e.g. o
+# tbb_config.h:56:7: warning: "__GLIBCPP__" is not defined, evaluates to 0 [-Wundef]
+# elif __GLIBCPP__ || __GLIBCXX__
+export CFLAGS="$(echo $CFLAGS | sed -e's/-Wundef //') -w"
+export CXXFLAGS="$(echo $CXXFLAGS | sed -e's/-Wundef //') -w"
+export CPPFLAGS="$(echo $CPPFLAGS | sed -e's/-Wundef //')"
+export DEBUG_CXXFLAGS="$(echo $DEBUG_CXXFLAGS | sed -e's/-Wundef //') -w"
+export DEBUG_CPPFLAGS="$(echo $DEBUG_CPPFLAGS | sed -e's/-Wundef //')"
+echo "CFLAGS='$CFLAGS'"
+echo "CXXFLAGS='$CXXFLAGS'"
+echo "CPPFLAGS='$CPPFLAGS'"
+echo "DEBUG_CXXFLAGS='$DEBUG_CXXFLAGS'"
+echo "DEBUG_CPPFLAGS='$DEBUG_CPPFLAGS'"
+echo "LDFLAGS='$LDFLAGS'"
+env
+export M4=${PREFIX}/bin/m4
+mkdir build
+cd build
+# ODIN and ABC are disabled to keep build time less than Travis CI timeout.
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWITH_ODIN=OFF \
+    -DWITH_ABC=OFF \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    ..
+grep -i flags CMakeCache.txt
+make -k -j$CPU_COUNT || make VERBOSE=1
+make test
+make -j$CPU_COUNT install
+
+mkdir -p ${PREFIX}/lib
+mv ${PREFIX}/bin/*.a ${PREFIX}/lib/

--- a/pnr/quicklogic-vtr/meta.yaml
+++ b/pnr/quicklogic-vtr/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-','_') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+package:
+  name: vtr
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/vtr-verilog-to-routing.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - bison
+    - cmake
+    - flex
+    - pkg-config
+    - tbb
+    - tbb-devel
+  run:
+    - tbb
+
+#test:
+#  commands:
+#    - ./run_reg_test.pl vtr_reg_basic
+#    - ./run_reg_test.pl vtr_reg_strong -j2
+
+about:
+  home: http://verilogtorouting.org/
+  license: MIT
+  license_file: LICENSE.md
+  summary: 'The Verilog-to-Routing (VTR) project is a world-wide collaborative effort to provide a open-source framework for conducting FPGA architecture and CAD research and development. The VTR design flow takes as input a Verilog description of a digital circuit, and a description of the target FPGA architecture.'


### PR DESCRIPTION
These are exactly the same as in the current master of https://github.com/QuickLogic-Corp/ql_conda_eda

Difference with SymbiFlow versions of vtr lies mostly in using `master` instead of `master+wip` branch of the source repository.