### PR TITLE
Add quicklogic-yosys-plugins recipe for Linux and macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,11 @@ jobs:
     os: linux
     dist: xenial
     env:
+    - PACKAGE=syn/quicklogic-yosys-plugins
+  - stage: "Has first level dependencies"
+    os: linux
+    dist: xenial
+    env:
     - PACKAGE=syn/symbiflow-yosys LIBFFI_VERSION=3.2.1
   - stage: "Has first level dependencies"
     os: linux
@@ -145,6 +150,11 @@ jobs:
     osx_image: xcode8.3
     env:
     - PACKAGE=syn/quicklogic-yosys EXTRA_BUILD_ARGS="--no-test"
+  - stage: "Has first level dependencies"
+    os: osx
+    osx_image: xcode8.3
+    env:
+    - PACKAGE=syn/quicklogic-yosys-plugins
   - stage: "Has first level dependencies"
     os: osx
     osx_image: xcode8.3

--- a/syn/quicklogic-yosys-plugins/build.sh
+++ b/syn/quicklogic-yosys-plugins/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+which pkg-config
+
+echo "PREFIX := $PREFIX" >> Makefile.conf
+
+make install
+#make install -j$CPU_COUNT
+#make -C fasm-plugin install -j$CPU_COUNT
+#make -C xdc-plugin install -j$CPU_COUNT
+

--- a/syn/quicklogic-yosys-plugins/meta.yaml
+++ b/syn/quicklogic-yosys-plugins/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: quicklogic-yosys-plugins
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/QuickLogic-Corp/yosys-symbiflow-plugins.git
+  git_rev: ql-ios
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make
+  host:
+    - pkg-config
+    - readline
+    - bison
+    - tk
+    - libffi
+    - flex
+    - iverilog
+    - quicklogic-yosys
+  run:
+    - quicklogic-yosys
+


### PR DESCRIPTION
This is almost the same recipe as can be currently found in the `QuickLogic-Corp/ql_conda_eda` repository.

The only changes are:
* name of the package,
* `quicklogic-yosys` requirement instead of `yosys`,
* removing `condarc` (ie. `ql_conda_eda` channel won't be used),
* `make` as a requirement because Travis' `make` fails macOS builds.