### PR TITLE
Add `quicklogic-*` metarecipes for `vtr`/`vtr-gui`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,6 +193,16 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=pnr/symbiflow-vtr-gui
+  - stage: "Has first level dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=pnr/quicklogic-vtr  # Uses: vtr
+  - stage: "Has first level dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=pnr/quicklogic-vtr-gui  # Uses: vtr-gui
   - stage: "Has second level dependencies"
     os: linux
     dist: xenial

--- a/pnr/quicklogic-vtr-gui/condarc
+++ b/pnr/quicklogic-vtr-gui/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/pnr/quicklogic-vtr-gui/meta.yaml
+++ b/pnr/quicklogic-vtr-gui/meta.yaml
@@ -1,0 +1,22 @@
+{% set ns = namespace(version='0.0', build_string='0') %}
+{% for package in resolved_packages('host') %}
+  {% if package.startswith( 'vtr-gui ' ) %}
+    {% set ns.version = package.split()[1] %}
+    {% set ns.build_string = package.split()[2] %}
+  {% endif %}
+{% endfor %}
+
+package:
+  name: quicklogic-vtr-gui
+  version: {{ ns.version }}
+build:
+  string: {{ ns.build_string }}
+requirements:
+  host:
+    - vtr-gui
+  run:
+    - vtr-gui={{ ns.version }}={{ ns.build_string }}
+about:
+  home: http://verilogtorouting.org/
+  license: MIT
+  summary: 'A metapackage installing upstream version of the Verilog-to-Routing (VTR) with GUI support.'

--- a/pnr/quicklogic-vtr/meta.yaml
+++ b/pnr/quicklogic-vtr/meta.yaml
@@ -1,0 +1,22 @@
+{% set ns = namespace(version='0.0', build_string='0') %}
+{% for package in resolved_packages('host') %}
+  {% if package.startswith( 'vtr ' ) %}
+    {% set ns.version = package.split()[1] %}
+    {% set ns.build_string = package.split()[2] %}
+  {% endif %}
+{% endfor %}
+
+package:
+  name: quicklogic-vtr
+  version: {{ ns.version }}
+build:
+  string: {{ ns.build_string }}
+requirements:
+  host:
+    - vtr
+  run:
+    - vtr={{ ns.version }}={{ ns.build_string }}
+about:
+  home: http://verilogtorouting.org/
+  license: MIT
+  summary: 'A metapackage installing upstream version of the Verilog-to-Routing (VTR).'


### PR DESCRIPTION
Installing built `quicklogic-vtr` metapackage will result in installing
`vtr` package in the exact same version and build as the metapackage.

Metapackages built in CI can be tested using:
```
conda install -c litex-hub/label/travis-quicklogic-vtr-201232771 quicklogic-vtr
conda install -c conda-forge -c litex-hub/label/travis-quicklogic-vtr-201232771 quicklogic-vtr-gui
```