### PR TITLE
Stop using `resolved_packages`

### DIFF
--- a/pnr/arachne/build.sh
+++ b/pnr/arachne/build.sh
@@ -13,7 +13,7 @@ unset CPPFLAGS
 unset DEBUG_CXXFLAGS
 unset DEBUG_CPPFLAGS
 
-export ICEBOX=$(realpath $(dirname $(which $CC))/../share/icebox)
+export ICEBOX=$PREFIX/share/icebox
 echo
 echo "IceStorm config"
 echo "--------------------------------------"

--- a/pnr/arachne/meta.yaml
+++ b/pnr/arachne/meta.yaml
@@ -23,22 +23,25 @@ requirements:
     - {{ compiler('cxx') }}
     - bison
     - flex
+    - pkg-config
+    - readline
+  host:
     - icestorm
     - iverilog
     - libffi
-    - libgcc-ng
-    - pkg-config
-    - readline
     - tk
     - symbiflow-yosys
   run:
     - icestorm
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
-  {% for package in resolved_packages('build') %}
-    - {{ package }}
-  {% endfor %}
+    - iverilog
+    - libffi
+    - tk
+    - symbiflow-yosys
+
+test:
+  commands:
+    - arachne-pnr -h
+    - arachne-pnr -v
 
 about:
   home: http://www.clifford.at/arachne-pnr/

--- a/sim/verilator/meta.yaml
+++ b/sim/verilator/meta.yaml
@@ -25,24 +25,15 @@ requirements:
     - {{ compiler('c') }} 4.0   [osx]
     - {{ compiler('cxx') }} 4.0 [osx]
   host:
-    - {{ compiler('c') }}       [not osx]
-    - {{ compiler('cxx') }}     [not osx]
-    - {{ compiler('c') }} 4.0   [osx]
-    - {{ compiler('cxx') }} 4.0 [osx]
     - bison
     - flex
     - zlib
-  run:
-    - {{ compiler('cxx') }}     [not osx]
-    - {{ compiler('cxx') }} 4.0 [osx]
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
-  {% for package in resolved_packages('build') %}
-    - {{ package }}
-  {% endfor %}
 
 test:
+  requires:
+    - gxx_linux-64   [linux]
+    - clangxx_osx-64 [osx]
+    - make
   files:
     - test/counter.v
     - test/counter_tb.v

--- a/sim/verilator/run_test.sh
+++ b/sim/verilator/run_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-set +x
+set -x
 
 $PREFIX/bin/verilator -V
 #$PREFIX/bin/verilator --help || true


### PR DESCRIPTION
Using `resolved_packages` in run requirements results in adding exact
builds of the packages used during building as dependencies.

It often leads to dependency conflicts so it's better to have them
copied.

Other changes are because:
* verilator needs some C++ compiler during testing but it's not
  necessary for running the verilator itself,
* arachne-pnr had icebox path dependent on gcc path which restricted
  more reasonable separation of build/host packages.