### PR TITLE
bit: prjxray-tools: remove not needed condarc

### DIFF
--- a/bit/prjxray-tools/condarc
+++ b/bit/prjxray-tools/condarc
@@ -1,3 +1,0 @@
-channels:
-  - pkgw-forge
-  - conda-forge


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The presence of condarc, specifically the conda-forge channel was forcing the libgcc-ng package to be >= 9.3.0 generating conflicts with other packages that require a previous version of the libgcc-ng package.

In general though, we do not want to make use of conda-forge, unless strictly required