### PR TITLE
nextpnr-ice40: Fix building on macOS

### DIFF
--- a/pnr/nextpnr/ice40/meta.yaml
+++ b/pnr/nextpnr/ice40/meta.yaml
@@ -27,11 +27,6 @@ requirements:
     - m2-base    [win]
     - fontconfig [not win]
     - cmake
-    - python 3.7
-    - boost     {{ boost_version }}
-    - boost-cpp {{ boost_version }}
-    - libboost  {{ boost_version }}
-    - py-boost  {{ boost_version }}
   host:
     - m2-bison   [win]
     - m2-flex    [win]


### PR DESCRIPTION
The boost packages v1.73 conflict with the clang 4.0 on macOS. It seems
it requires newer version of the compiler.

However, packages such as libraries linked should be placed in a `host`
environment. Also, there's rarely a need to have the same package as
both the `build` and the `host` requirement.

Therefore, to solve conflicts, the packages mentioned in both have been
removed from the `build` environment.