### PR TITLE
vtr: add capnp-schema-dir script to get its path

### DIFF
--- a/pnr/vtr-gui/build.sh
+++ b/pnr/vtr-gui/build.sh
@@ -25,3 +25,8 @@ make install
 
 mkdir -p ${PREFIX}/lib
 mv ${PREFIX}/bin/*.a ${PREFIX}/lib/
+
+CAPNP_SCHEMAS=${PREFIX}/bin/capnp-schemas-dir
+
+echo -e "#!/bin/bash\n\necho ${PREFIX}/capnp" > ${CAPNP_SCHEMAS}
+chmod +x ${CAPNP_SCHEMAS}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The capnp-schema-dir is essential in tool-perf to get the path of the `capnp` schemas. Given the recent transition towards using upstream tools packages, this script was absent.