### PR TITLE
Add python-constraint to avoid conda-forge dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=misc/magic
+  - stage: "No dependencies"
+    os: linux
+    dist: xenial
+    env:
+    - PACKAGE=misc/python-constraint
 
  # EDA Tools - Bitstream Tools
   # Linux
@@ -183,7 +188,7 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=pnr/vtr-gui
-  - stage: "No dependencies"
+  - stage: "Has first level dependencies"
     os: linux
     dist: xenial
     env:

--- a/misc/python-constraint/meta.yaml
+++ b/misc/python-constraint/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "python-constraint" %}
+{% set version = "1.4.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.bz2"
+  sha256: 501d6f17afe0032dfc6ea6c0f8acc12e44f992733f00e8538961031ef27ccb8e
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+    - CONDA_OUT
+    - TEST_PACKAGE
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - constraint
+    - examples
+    - examples.abc
+    - examples.coins
+    - examples.crosswords
+    - examples.einstein
+    - examples.queens
+    - examples.rooks
+    - examples.studentdesks
+    - examples.sudoku
+    - examples.wordmath
+    - examples.xsum
+
+about:
+  home: "https://github.com/python-constraint/python-constraint"
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE
+  summary: "python-constraint is a module implementing support for handling CSPs (Constraint Solving Problems) over finite domain"

--- a/pnr/vtr-optimized/condarc
+++ b/pnr/vtr-optimized/condarc
@@ -1,2 +1,0 @@
-channels:
-  - conda-forge


### PR DESCRIPTION
Any packages with a `condarc` specifying outside channels will require those channels to be available to install them.

Depending in conda-forge is undesirable because it can conflict with many of the default packages. `pip` cannot be used directly in a conda recipe, so PyPI packages must be converted to Conda packages.

This has caused problems with `vtr-optimized` ([PR](https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1892)), which this PR aims to resolve, but there are other packages using `condarc` as well.