### PR TITLE
vtr-optimized: Give highest priority to the `defaults` channel

### DIFF
--- a/pnr/vtr-optimized/condarc
+++ b/pnr/vtr-optimized/condarc
@@ -1,2 +1,3 @@
 channels:
+  - defaults
   - conda-forge


### PR DESCRIPTION
Such change will make `conda-build` get all required packages from the
`defaults` channel if they only exist there. Only the packages that
aren't available in that channel will be taken from the `conda-forge`
channel (`python-constraint`).