### PR TITLE
Build uhdm-integration packages for python 3.7 and 3.8

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 66
+  NUM_OF_JOBS: 68
 defaults:
   run:
     shell: bash
@@ -756,12 +756,27 @@ jobs:
       - uses: litex-hub/litex-conda-ci@master
 
   #56
-  surelog-uhdm-linux:
+  surelog-uhdm-linux-py37:
     runs-on: "ubuntu-16.04"
     env:
       PACKAGE: "sv-front/surelog-uhdm"
       USE_SYSTEM_GCC_VERSION: "9"
       OS_NAME: "linux"
+      PYTHON_VERSION: "3.7"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: litex-hub/litex-conda-ci@master
+
+  #67
+  surelog-uhdm-linux-py38:
+    runs-on: "ubuntu-16.04"
+    env:
+      PACKAGE: "sv-front/surelog-uhdm"
+      USE_SYSTEM_GCC_VERSION: "9"
+      OS_NAME: "linux"
+      PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -769,12 +784,27 @@ jobs:
       - uses: litex-hub/litex-conda-ci@master
 
   #57
-  yosys-uhdm-linux:
+  yosys-uhdm-linux-py37:
     runs-on: "ubuntu-16.04"
     env:
       PACKAGE: "syn/yosys-uhdm"
       USE_SYSTEM_GCC_VERSION: "9"
       OS_NAME: "linux"
+      PYTHON_VERSION: "3.7"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: litex-hub/litex-conda-ci@master
+
+  #68
+  yosys-uhdm-linux-py38:
+    runs-on: "ubuntu-16.04"
+    env:
+      PACKAGE: "syn/yosys-uhdm"
+      USE_SYSTEM_GCC_VERSION: "9"
+      OS_NAME: "linux"
+      PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -797,7 +827,7 @@ jobs:
   #59
   uhdm-integration-verilator-linux:
     runs-on: "ubuntu-16.04"
-    needs: ["surelog-uhdm-linux", "verilator-uhdm-linux"]
+    needs: ["surelog-uhdm-linux-py37", "surelog-uhdm-linux-py38", "verilator-uhdm-linux"]
     env:
       PACKAGE: "sim/uhdm-integration-verilator"
       USE_SYSTEM_GCC_VERSION: "9"
@@ -811,7 +841,7 @@ jobs:
   #60
   uhdm-integration-yosys-linux:
     runs-on: "ubuntu-16.04"
-    needs: ["surelog-uhdm-linux", "yosys-uhdm-linux"]
+    needs: ["surelog-uhdm-linux-py37", "surelog-uhdm-linux-py38", "yosys-uhdm-linux-py37", "yosys-uhdm-linux-py38"]
     env:
       PACKAGE: "sim/uhdm-integration-yosys"
       USE_SYSTEM_GCC_VERSION: "9"

--- a/sv-front/surelog-uhdm/condarc
+++ b/sv-front/surelog-uhdm/condarc
@@ -1,3 +1,2 @@
 channels:
-  - defaults
   - conda-forge

--- a/sv-front/surelog-uhdm/meta.yaml
+++ b/sv-front/surelog-uhdm/meta.yaml
@@ -1,6 +1,9 @@
 # Use `conda-build-prepare` before building for a better version string.
 {% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X.X', GIT_DESCRIBE_NUMBER|int,   GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
+{% set python_version = PYTHON_VERSION | default('3.7') %}
+{% set py_suffix = 'py%s'|format(python_version|replace('.', '')) %}
+
 package:
   name: surelog-uhdm
   version: {{ version }}
@@ -13,7 +16,7 @@ build:
   # number: 201803050325
   number: {{ environ.get('DATE_NUM') }}
   # string: 20180305_0325
-  string: {{ environ.get('DATE_STR') }}
+  string: {{ environ.get('DATE_STR') }}_{{ py_suffix }}
   script_env:
     - CI
     - USE_SYSTEM_GCC_VERSION
@@ -22,7 +25,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - python {{ python }}
+    - python {{ python_version }}
     - cmake
     - pkg-config
     - libuuid
@@ -31,7 +34,7 @@ requirements:
     - libunwind
     - swig
   run:
-    - python {{ python }}
+    - python {{ python_version }}
     - gperftools
     - libunwind
 

--- a/syn/yosys-uhdm/condarc
+++ b/syn/yosys-uhdm/condarc
@@ -1,3 +1,2 @@
 channels:
-  - defaults
   - conda-forge

--- a/syn/yosys-uhdm/meta.yaml
+++ b/syn/yosys-uhdm/meta.yaml
@@ -1,5 +1,7 @@
 # Use `conda-build-prepare` before building for a better version string.
 {% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X.X', GIT_DESCRIBE_NUMBER|int,   GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set python_version = PYTHON_VERSION | default('3.7') %}
+{% set py_suffix = 'py%s'|format(python_version|replace('.', '')) %}
 
 package:
   name: yosys-uhdm
@@ -11,7 +13,7 @@ source:
 
 build:
   number: {{ environ.get('DATE_NUM') }}
-  string: {{ environ.get('DATE_STR') }}
+  string: {{ environ.get('DATE_STR') }}_{{ py_suffix }}
   script_env:
     - CI
     - USE_SYSTEM_GCC_VERSION
@@ -20,7 +22,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - python {{ python }}
+    - python {{ python_version }}
     - cmake
     - pkg-config
     - libuuid
@@ -30,6 +32,7 @@ requirements:
     - swig
     - ncurses
   run:
+    - python {{python_version}}
     - ncurses
     - readline
     - libffi


### PR DESCRIPTION
This PR introduces additional `uhdm-integration` packages with python 3.8 dependency. This is required in SystemVerilog testing workflow (encountering the same problems as in https://github.com/litex-hub/litex-conda-eda/pull/68)