### PR TITLE
Fixes for uhdm-yosys package

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -788,7 +788,6 @@ jobs:
     runs-on: "ubuntu-16.04"
     env:
       PACKAGE: "syn/yosys-uhdm"
-      USE_SYSTEM_GCC_VERSION: "9"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
@@ -802,7 +801,6 @@ jobs:
     runs-on: "ubuntu-16.04"
     env:
       PACKAGE: "syn/yosys-uhdm"
-      USE_SYSTEM_GCC_VERSION: "9"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:

--- a/syn/yosys-uhdm/build.sh
+++ b/syn/yosys-uhdm/build.sh
@@ -6,13 +6,16 @@ set -x
 export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/"
 export CXXFLAGS="$CXXFLAGS -I$BUILD_PREFIX/include"
 export LDFLAGS="$CXXFLAGS -L$BUILD_PREFIX/lib -lrt -ltinfo"
-export CC=gcc-${USE_SYSTEM_GCC_VERSION}
-export CXX=g++-${USE_SYSTEM_GCC_VERSION}
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$BUILD_PREFIX/lib"
 
 cd Surelog && make PREFIX=$PWD/../image release install -j$CPU_COUNT && cd ..
-make PREFIX=$PWD/image install -j$CPU_COUNT
 
-mkdir -p "$PREFIX/bin"
+#Create aliases for gcc/gxx as `abc` uses them directly in Makefile
+alias gcc=x86_64-conda_cos6-linux-gnu-gcc
+alias gxx=x86_64-conda_cos6-linux-gnu-gcc
+make ENABLE_READLINE=0 CONFIG=conda-linux PROGRAM_PREFIX=uhdm- PREFIX=$PWD/image install -j$CPU_COUNT
 
-cp "$SRC_DIR/image/bin/yosys" "$PREFIX/bin/yosys-uhdm"
+mkdir -p "$PREFIX/"
+
+cp -r $SRC_DIR/image/* "$PREFIX/"
+

--- a/syn/yosys-uhdm/meta.yaml
+++ b/syn/yosys-uhdm/meta.yaml
@@ -10,13 +10,14 @@ package:
 source:
   git_rev: uhdm-yosys
   git_url: https://github.com/antmicro/yosys.git
+  patches:
+    - yosys.patch
 
 build:
   number: {{ environ.get('DATE_NUM') }}
   string: {{ environ.get('DATE_STR') }}_{{ py_suffix }}
   script_env:
     - CI
-    - USE_SYSTEM_GCC_VERSION
 
 requirements:
   build:
@@ -39,4 +40,4 @@ requirements:
 
 test:
     commands:
-        - yosys-uhdm --version
+        - uhdm-yosys --version

--- a/syn/yosys-uhdm/yosys.patch
+++ b/syn/yosys-uhdm/yosys.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index 72ca15e36..85f131096 100644
+--- a/Makefile
++++ b/Makefile
+@@ -342,6 +342,19 @@ LDLIBS := $(filter-out -lrt,$(LDLIBS))
+ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC -fpermissive -w"
+ ABCMKARGS += LIBS="-lpthread -s" ABC_USE_NO_READLINE=0 CC="x86_64-w64-mingw32-gcc" CXX="$(CXX)"
+ EXE = .exe
++else ifeq ($(CONFIG),conda-linux)
++CXX = x86_64-conda_cos6-linux-gnu-gcc
++LD = x86_64-conda_cos6-linux-gnu-gcc
++CXXFLAGS += -std=c++11 -Os -fno-merge-constants
++CFLAGS += -Wno-unused-function -Wno-unused-but-set-variable
++ABCMKARGS += "ABC_READLINE_INCLUDES=-I${PREFIX}/include"
++ABCMKARGS += "ABC_READLINE_LIBRARIES=-L${PREFIX}/lib -lreadline"
++
++else ifeq ($(CONFIG),conda-mac)
++CXX = x86_64-apple-darwin13.4.0-clang
++LD = x86_64-apple-darwin13.4.0-clang++
++CXXFLAGS += -std=c++11 -Os
++ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
+ 
+ else ifneq ($(CONFIG),none)
+ $(error Invalid CONFIG setting '$(CONFIG)'. Valid values: clang, gcc, gcc-4.8, emcc, mxe, msys2, msys2-64)
+


### PR DESCRIPTION
This PR fixes encouraged problems with ``uhdm-yosys`` package in ``fpga-tool-perf`` :

- includes whole yosys install in package (not only binary yosys file)
- uses conda compiler to compile yosys (and sets gcc/gxx aliases to conda compiler, as ``abc`` is using them directly, this fixes the problem with wrong path to yosys - share directory after compilation)
- uses ``PROGRAM_PREFIX`` to add prefix to the output files - this way we won't conflict with other yosys installed in the system, but it changes binary name to ``uhdm-yosys`` from ``yosys-uhdm`` (this means we need to adapt all repositories that is already using this package after merge.).
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>